### PR TITLE
Strip empty line entries

### DIFF
--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -17,7 +17,7 @@ export const envToString = (parsed: EnvObject) =>
 	getObjKeys(parsed)
 		.map(key => `${key}=${parsed[key] || ""}`)
 		.join("\r\n")
-		.replace(/(__\w+_\d__=)/g, "");
+		.replace(/(__\w+_\d+__=)/g, "");
 
 export const writeToExampleEnv = (path: string, parsedEnv: object) => {
 	fs.writeFile(path, envToString(parsedEnv), err => {


### PR DESCRIPTION
Remove empty line entries that exist when variables are separated with 10 empty lines and above

Closes [#7](https://github.com/codeshifu/sync-dotenv/issues/7)