### PR TITLE
Preserve inline comments

### DIFF
--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -29,6 +29,18 @@ export const writeToSampleEnv = (path: string, parsedEnv: object) => {
 export const emptyObjProps = (obj: EnvObject) => {
 	const objCopy = { ...obj };
 	Object.keys(objCopy).forEach(key => {
+		if (objCopy[key].includes("#")) {
+			if (objCopy[key].match(/(".*"|'.*')/g)) {
+				const objArr = objCopy[key].split(/(".*"|'.*')/);
+				objCopy[key] = " " + objArr[objArr.length - 1].trim();
+			} else {
+				const objArr = objCopy[key].split("#");
+				objCopy[key] = ` #${objArr[objArr.length - 1]}`;
+			}
+
+			return;
+		}
+
 		if (!key.startsWith("__COMMENT_")) {
 			objCopy[key] = "";
 		}
@@ -64,7 +76,7 @@ export const removeStaleVarsFromEnv = (env: object, vars: EnvObject[]) => {
 	vars.forEach(envObj => {
 		const [key] = Object.keys(envObj);
 		if (envCopy.hasOwnProperty(key)) {
-			envCopy[key] = envObj[key];
+			envCopy[key] = envCopy[key] || envObj[key];
 		}
 	});
 

--- a/test/lib.spec.ts
+++ b/test/lib.spec.ts
@@ -43,6 +43,7 @@ DB_PORT=\r\n
 DB_DATABASE=\r\n
 DB_USERNAME=\r\n
 DB_PASSWORD=\r\n
+test4="key#a23" # with comment
 OTHER_ENV=`;
 
 describe("sync-dotenv lib", () => {


### PR DESCRIPTION
Preserve comments inline with .env values

e.g.

```
test2=has # wow! comment
test4="key#a23" # with comment
test6='kadkasdkjf#' # nice comment
```