### PR TITLE
Optionally preserve variables in sample env file

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "presets": ["@babel/preset-env", "@babel/preset-typescript"],
   "plugins": [
     "@babel/proposal-class-properties",
-    "@babel/proposal-object-rest-spread"
+    "@babel/proposal-object-rest-spread",
+    "@babel/plugin-transform-runtime"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,8 @@
   "[javascriptreact]": {
     "editor.formatOnSave": false
   },
-  "eslint.autoFixOnSave": true,
-  "prettier.disableLanguages": ["javascript", "javascriptreact"]
+  "prettier.disableLanguages": ["javascript", "javascriptreact"],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }

--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ Or with file other than `.env.example`
 }
 ```
 
+### Preserving variables in sample env
+
+Sometimes you need to preserve certain variables in your example env file, you can optionally allow this by adding a `sync-dotenv` config in `package.json` like so
+
+```js
+// package.json
+"scripts": {
+  ...
+},
+"sync-dotenv": {
+  "preserve": ["CHANNEL"]
+}
+```
+
 ## Related
 
 - [parse-dotenv](https://github.com/codeshifu/parse-dotenv) - zero dependency `.env` to javascript object parser

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,21 +5,59 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/cli": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.4.3.tgz",
-			"integrity": "sha512-cbC5H9iTDV9H7sMxK5rUm18UbdVPNTPqgdzmQAkOUP3YLysgDWLZaysVAfylK49rgTlzL01a6tXyq9rCb3yLhQ==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.8.4.tgz",
+			"integrity": "sha512-XXLgAm6LBbaNxaGhMAznXXaxtCWfuv6PIDJ9Alsy9JYTOh+j2jJz+L/162kkfU1j/pTSxK1xGmlwI4pdIMkoag==",
 			"dev": true,
 			"requires": {
-				"chokidar": "^2.0.4",
-				"commander": "^2.8.1",
+				"chokidar": "^2.1.8",
+				"commander": "^4.0.1",
 				"convert-source-map": "^1.1.0",
 				"fs-readdir-recursive": "^1.1.0",
 				"glob": "^7.0.0",
-				"lodash": "^4.17.11",
-				"mkdirp": "^0.5.1",
-				"output-file-sync": "^2.0.0",
+				"lodash": "^4.17.13",
+				"make-dir": "^2.1.0",
 				"slash": "^2.0.0",
 				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"chokidar": {
+					"version": "2.1.8",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+					"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"anymatch": "^2.0.0",
+						"async-each": "^1.0.1",
+						"braces": "^2.3.2",
+						"fsevents": "^1.2.7",
+						"glob-parent": "^3.1.0",
+						"inherits": "^2.0.3",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^4.0.0",
+						"normalize-path": "^3.0.0",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.2.1",
+						"upath": "^1.1.1"
+					}
+				},
+				"commander": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+					"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+					"dev": true
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				}
 			}
 		},
 		"@babel/code-frame": {
@@ -102,6 +140,29 @@
 				"@babel/types": "^7.0.0"
 			}
 		},
+		"@babel/helper-builder-react-jsx": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.4.tgz",
+			"integrity": "sha512-kvbfHJNN9dg4rkEM4xn1s8d1/h6TYNvajy9L1wx4qLn9HFg0IkTsQi4rfBe92nxrPUFcMsHoMV+8rU7MJb3fCA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.7.4",
+				"esutils": "^2.0.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
 		"@babel/helper-call-delegate": {
 			"version": "7.4.4",
 			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
@@ -125,6 +186,32 @@
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-replace-supers": "^7.5.5",
 				"@babel/helper-split-export-declaration": "^7.4.4"
+			}
+		},
+		"@babel/helper-create-regexp-features-plugin": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
+			"integrity": "sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.6.0"
+			},
+			"dependencies": {
+				"regexpu-core": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+					"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.1.0",
+						"regjsgen": "^0.5.0",
+						"regjsparser": "^0.6.0",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.1.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-define-map": {
@@ -277,6 +364,12 @@
 				"@babel/types": "^7.4.4"
 			}
 		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
+			"integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
+			"dev": true
+		},
 		"@babel/helper-wrap-function": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
@@ -338,6 +431,16 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-proposal-dynamic-import": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz",
+			"integrity": "sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.7.4"
+			}
+		},
 		"@babel/plugin-proposal-json-strings": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
@@ -388,6 +491,24 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-syntax-dynamic-import": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
+			"integrity": "sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-flow": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.7.4.tgz",
+			"integrity": "sha512-2AMAWl5PsmM5KPkB22cvOkUyWk6MjUaqhHNU5nSPUl/ns3j5qLfw2SuYP5RbVZ0tfLvePr4zUScbICtDP2CUNw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-syntax-json-strings": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
@@ -419,6 +540,15 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
 			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.4.tgz",
+			"integrity": "sha512-wdsOw0MvkL1UIgiQ/IFr3ETcfv1xb8RMM0H9wbiDyLaJFyiDg5oZvDLCXosIXmFeIlweML5iOBXAkqddkYNizg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -534,6 +664,16 @@
 			"requires": {
 				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-flow-strip-types": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.7.4.tgz",
+			"integrity": "sha512-w9dRNlHY5ElNimyMYy0oQowvQpwt/PRHI0QS98ZJCTZU2bvSnKXo5zEiD5u76FBPigTm8TkqzmnUTg16T7qbkA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-flow": "^7.7.4"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
@@ -665,6 +805,28 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-transform-react-jsx": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.4.tgz",
+			"integrity": "sha512-LixU4BS95ZTEAZdPaIuyg/k8FiiqN9laQ0dMHB4MlpydHY53uQdWCUrwjLr5o6ilS6fAgZey4Q14XBjl5tL6xw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-builder-react-jsx": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.7.4"
+			},
+			"dependencies": {
+				"@babel/plugin-syntax-jsx": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.7.4.tgz",
+					"integrity": "sha512-wuy6fiMe9y7HeZBWXYCGt2RGxZOj0BImZ9EyXJVnVGBKO/Br592rbR3rtIQn0eQhAk9vqaKP5n8tVqEFBQMfLg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				}
+			}
+		},
 		"@babel/plugin-transform-regenerator": {
 			"version": "7.4.5",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
@@ -681,6 +843,46 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-runtime": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.0.tgz",
+			"integrity": "sha512-pUu9VSf3kI1OqbWINQ7MaugnitRss1z533436waNXp+0N3ur3zfut37sXiQMxkuCF4VUjwZucen/quskCh7NHw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"resolve": "^1.8.1",
+				"semver": "^5.5.1"
+			},
+			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+					"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.9.0",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
@@ -893,6 +1095,12 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@iarna/toml": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.3.tgz",
+			"integrity": "sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==",
+			"dev": true
+		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -906,6 +1114,67 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+		},
+		"@parcel/fs": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-1.11.0.tgz",
+			"integrity": "sha512-86RyEqULbbVoeo8OLcv+LQ1Vq2PKBAvWTU9fCgALxuCTbbs5Ppcvll4Vr+Ko1AnmMzja/k++SzNAwJfeQXVlpA==",
+			"dev": true,
+			"requires": {
+				"@parcel/utils": "^1.11.0",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.6.2"
+			}
+		},
+		"@parcel/logger": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-1.11.1.tgz",
+			"integrity": "sha512-9NF3M6UVeP2udOBDILuoEHd8VrF4vQqoWHEafymO1pfSoOMfxrSJZw1MfyAAIUN/IFp9qjcpDCUbDZB+ioVevA==",
+			"dev": true,
+			"requires": {
+				"@parcel/workers": "^1.11.0",
+				"chalk": "^2.1.0",
+				"grapheme-breaker": "^0.3.2",
+				"ora": "^2.1.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@parcel/utils": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-1.11.0.tgz",
+			"integrity": "sha512-cA3p4jTlaMeOtAKR/6AadanOPvKeg8VwgnHhOyfi0yClD0TZS/hi9xu12w4EzA/8NtHu0g6o4RDfcNjqN8l1AQ==",
+			"dev": true
+		},
+		"@parcel/watcher": {
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-1.12.1.tgz",
+			"integrity": "sha512-od+uCtCxC/KoNQAIE1vWx1YTyKYY+7CTrxBJPRh3cDWw/C0tCtlBMVlrbplscGoEpt6B27KhJDCv82PBxOERNA==",
+			"dev": true,
+			"requires": {
+				"@parcel/utils": "^1.11.0",
+				"chokidar": "^2.1.5"
+			}
+		},
+		"@parcel/workers": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-1.11.0.tgz",
+			"integrity": "sha512-USSjRAAQYsZFlv43FUPdD+jEGML5/8oLF0rUzPQTtK4q9kvaXr49F5ZplyLz5lox78cLZ0TxN2bIDQ1xhOkulQ==",
+			"dev": true,
+			"requires": {
+				"@parcel/utils": "^1.11.0",
+				"physical-cpu-count": "^2.0.0"
+			}
 		},
 		"@samverschueren/stream-to-observable": {
 			"version": "0.3.0",
@@ -1083,6 +1352,12 @@
 				"@types/sinon": "*"
 			}
 		},
+		"abab": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+			"integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+			"dev": true
+		},
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1090,9 +1365,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-			"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+			"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
 			"dev": true
 		},
 		"acorn-dynamic-import": {
@@ -1101,10 +1376,26 @@
 			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
 			"dev": true
 		},
+		"acorn-globals": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+			"dev": true,
+			"requires": {
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
+			}
+		},
 		"acorn-jsx": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
 			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+			"dev": true
+		},
+		"acorn-walk": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
 			"dev": true
 		},
 		"ajv": {
@@ -1175,6 +1466,15 @@
 			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
+			}
+		},
+		"ansi-to-html": {
+			"version": "0.6.13",
+			"resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.13.tgz",
+			"integrity": "sha512-Ys2/umuaTlQvP9DLkaa7UzRKF2FLrfod/hNHXS9QhXCrw7seObG6ksOGmNz3UoK+adwM8L9vQfG7mvaxfJ3Jvw==",
+			"dev": true,
+			"requires": {
+				"entities": "^1.1.2"
 			}
 		},
 		"any-observable": {
@@ -1275,6 +1575,12 @@
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
 		"array-filter": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
@@ -1346,6 +1652,44 @@
 				"safer-buffer": "~2.1.0"
 			}
 		},
+		"asn1.js": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"assert": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+			"integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+			"dev": true,
+			"requires": {
+				"object-assign": "^4.1.1",
+				"util": "0.10.3"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+					"dev": true
+				},
+				"util": {
+					"version": "0.10.3",
+					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.1"
+					}
+				}
+			}
+		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -1388,6 +1732,12 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
 			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+			"dev": true
+		},
+		"async-limiter": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
 			"dev": true
 		},
 		"asynckit": {
@@ -1472,11 +1822,60 @@
 			"integrity": "sha512-BHw2WriDbnLwaaIydAjVeXXKBal0pWlFWxfo0UKL2CTaSorvRocrsTflni/mzIOP8c+EJ8xHqtbre8GbIm4ehQ==",
 			"dev": true
 		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
+			"requires": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+					"dev": true
+				}
+			}
+		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			},
+			"dependencies": {
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+					"dev": true
+				}
+			}
+		},
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
 			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
 			"dev": true
+		},
+		"babylon-walk": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/babylon-walk/-/babylon-walk-1.0.2.tgz",
+			"integrity": "sha1-OxWl3btIKni0zpwByLoYFwLZ1s4=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.11.6",
+				"babel-types": "^6.15.0",
+				"lodash.clone": "^4.5.0"
+			}
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -1533,6 +1932,12 @@
 				}
 			}
 		},
+		"base64-js": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+			"dev": true
+		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1554,6 +1959,15 @@
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
 		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"bl": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -1563,6 +1977,12 @@
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"
 			}
+		},
+		"bn.js": {
+			"version": "4.11.8",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+			"dev": true
 		},
 		"boolbase": {
 			"version": "1.0.0",
@@ -1621,6 +2041,24 @@
 				}
 			}
 		},
+		"brfs": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
+			"integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
+			"dev": true,
+			"requires": {
+				"quote-stream": "^1.0.1",
+				"resolve": "^1.1.5",
+				"static-module": "^2.2.0",
+				"through2": "^2.0.0"
+			}
+		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"dev": true
+		},
 		"brotli-size": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/brotli-size/-/brotli-size-0.0.3.tgz",
@@ -1631,11 +2069,96 @@
 				"iltorb": "^2.0.5"
 			}
 		},
+		"browser-process-hrtime": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+			"dev": true
+		},
 		"browser-stdout": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
+		},
+		"browserify-aes": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+			"dev": true,
+			"requires": {
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"browserify-cipher": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+			"dev": true,
+			"requires": {
+				"browserify-aes": "^1.0.4",
+				"browserify-des": "^1.0.0",
+				"evp_bytestokey": "^1.0.0"
+			}
+		},
+		"browserify-des": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+			"dev": true,
+			"requires": {
+				"cipher-base": "^1.0.1",
+				"des.js": "^1.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"browserify-rsa": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.0",
+				"randombytes": "^2.0.1"
+			}
+		},
+		"browserify-sign": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.1",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.2",
+				"elliptic": "^6.0.0",
+				"inherits": "^2.0.1",
+				"parse-asn1": "^5.0.0"
+			}
+		},
+		"browserify-zlib": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+			"dev": true,
+			"requires": {
+				"pako": "~1.0.5"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+					"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+					"dev": true
+				}
+			}
 		},
 		"browserslist": {
 			"version": "4.6.6",
@@ -1665,9 +2188,9 @@
 			},
 			"dependencies": {
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				},
 				"os-homedir": {
@@ -1676,6 +2199,17 @@
 					"integrity": "sha512-saRNz0DSC5C/I++gFIaJTXoFJMRwiP5zHar5vV3xQ2TkgEw6hDCcU5F272JjUylpiVgBrZNQHnfjkLabTfb92Q==",
 					"dev": true
 				}
+			}
+		},
+		"buffer": {
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+			"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+			"dev": true,
+			"requires": {
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4",
+				"isarray": "^1.0.0"
 			}
 		},
 		"buffer-alloc": {
@@ -1694,6 +2228,12 @@
 			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
 			"dev": true
 		},
+		"buffer-equal": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+			"integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
+			"dev": true
+		},
 		"buffer-fill": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -1706,10 +2246,22 @@
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
 		},
+		"buffer-xor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+			"dev": true
+		},
 		"builtin-modules": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
 			"integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+			"dev": true
+		},
+		"builtin-status-codes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
 			"dev": true
 		},
 		"builtins": {
@@ -1963,6 +2515,16 @@
 			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
 			"dev": true
 		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"clap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -2049,6 +2611,12 @@
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
+		},
+		"cli-spinners": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
+			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
+			"dev": true
 		},
 		"cli-truncate": {
 			"version": "0.2.1",
@@ -2257,6 +2825,12 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"command-exists": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
+			"integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==",
+			"dev": true
+		},
 		"commander": {
 			"version": "2.20.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
@@ -2278,6 +2852,18 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			}
 		},
 		"concat-with-sourcemaps": {
 			"version": "1.1.0",
@@ -2316,10 +2902,22 @@
 			"integrity": "sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==",
 			"dev": true
 		},
+		"console-browserify": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+			"dev": true
+		},
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"dev": true
+		},
+		"constants-browserify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
 			"dev": true
 		},
 		"contains-path": {
@@ -2424,9 +3022,9 @@
 			},
 			"dependencies": {
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				}
 			}
@@ -2456,6 +3054,16 @@
 				}
 			}
 		},
+		"create-ecdh": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.0",
+				"elliptic": "^6.0.0"
+			}
+		},
 		"create-error-class": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -2463,6 +3071,33 @@
 			"dev": true,
 			"requires": {
 				"capture-stack-trace": "^1.0.0"
+			}
+		},
+		"create-hash": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"dev": true,
+			"requires": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
+			}
+		},
+		"create-hmac": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"dev": true,
+			"requires": {
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"cross-spawn": {
@@ -2476,6 +3111,25 @@
 				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
+			}
+		},
+		"crypto-browserify": {
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+			"dev": true,
+			"requires": {
+				"browserify-cipher": "^1.0.0",
+				"browserify-sign": "^4.0.0",
+				"create-ecdh": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.0",
+				"diffie-hellman": "^5.0.0",
+				"inherits": "^2.0.1",
+				"pbkdf2": "^3.0.3",
+				"public-encrypt": "^4.0.0",
+				"randombytes": "^2.0.0",
+				"randomfill": "^1.0.3"
 			}
 		},
 		"crypto-random-string": {
@@ -2785,6 +3439,21 @@
 				}
 			}
 		},
+		"cssom": {
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+			"dev": true
+		},
+		"cssstyle": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+			"dev": true,
+			"requires": {
+				"cssom": "0.3.x"
+			}
+		},
 		"currently-unhandled": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -2808,11 +3477,32 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
+		"data-urls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
+			}
+		},
 		"date-fns": {
 			"version": "1.30.1",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
 			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
 			"dev": true
+		},
+		"deasync": {
+			"version": "0.1.16",
+			"resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.16.tgz",
+			"integrity": "sha512-FNCjDwxGbhK+Ye8fmE3p2ahIjERhkbuwX+WVGZPtSbAh9LfE1Saa2p0l+f0t11sIlk9D8W+Bym+cDp6r5yghAQ==",
+			"dev": true,
+			"requires": {
+				"bindings": "^1.5.0",
+				"node-addon-api": "^1.7.1"
+			}
 		},
 		"debug": {
 			"version": "2.6.9",
@@ -2885,6 +3575,15 @@
 			"dev": true,
 			"requires": {
 				"strip-bom": "^3.0.0"
+			}
+		},
+		"defaults": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+			"dev": true,
+			"requires": {
+				"clone": "^1.0.2"
 			}
 		},
 		"defer-to-connect": {
@@ -3000,6 +3699,28 @@
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 			"dev": true
 		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"dev": true
+		},
+		"des.js": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+			"integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+			"dev": true
+		},
 		"detect-libc": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
@@ -3011,6 +3732,17 @@
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
+		},
+		"diffie-hellman": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.0",
+				"miller-rabin": "^4.0.0",
+				"randombytes": "^2.0.0"
+			}
 		},
 		"dir-glob": {
 			"version": "2.2.2",
@@ -3053,11 +3785,26 @@
 				}
 			}
 		},
+		"domain-browser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+			"dev": true
+		},
 		"domelementtype": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
 			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
 			"dev": true
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
+			"requires": {
+				"webidl-conversions": "^4.0.2"
+			}
 		},
 		"domhandler": {
 			"version": "2.4.2",
@@ -3093,11 +3840,26 @@
 			"integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
 			"dev": true
 		},
+		"dotenv-expand": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+			"integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+			"dev": true
+		},
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
+		},
+		"duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^2.0.2"
+			}
 		},
 		"duplexer3": {
 			"version": "0.1.4",
@@ -3115,6 +3877,12 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+			"dev": true
+		},
 		"electron-to-chromium": {
 			"version": "1.3.212",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.212.tgz",
@@ -3127,6 +3895,21 @@
 			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
 			"dev": true
 		},
+		"elliptic": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
+			}
+		},
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -3137,6 +3920,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+			"dev": true
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
 			"dev": true
 		},
 		"end-of-stream": {
@@ -3152,6 +3941,12 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
 			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+			"dev": true
+		},
+		"envinfo": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.0.tgz",
+			"integrity": "sha512-jDgnJaF/Btomk+m3PZDTTCb5XIIIX3zYItnCRfF73zVgvinLoRomuhi75Y4su0PtQxWz4v66XnLLckyvyJTOIQ==",
 			"dev": true
 		},
 		"error-ex": {
@@ -3199,11 +3994,45 @@
 			"integrity": "sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==",
 			"dev": true
 		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
+		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
+		},
+		"escodegen": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+			"dev": true,
+			"requires": {
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
+					"optional": true
+				}
+			}
 		},
 		"eslint": {
 			"version": "5.16.0",
@@ -3573,6 +4402,28 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+			"dev": true
+		},
+		"events": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+			"dev": true
+		},
+		"evp_bytestokey": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"dev": true,
+			"requires": {
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"execa": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -3778,6 +4629,32 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
 			"dev": true
 		},
+		"falafel": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.4.tgz",
+			"integrity": "sha512-0HXjo8XASWRmsS0X1EkhwEMZaD3Qvp7FfURwjLKjG1ghfRm/MGZl2r4cWUTv41KdNghTw4OUMmVtdGQp3+H+uQ==",
+			"dev": true,
+			"requires": {
+				"acorn": "^7.1.1",
+				"foreach": "^2.0.5",
+				"isarray": "^2.0.1",
+				"object-keys": "^1.0.6"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+					"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+					"dev": true
+				},
+				"isarray": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+					"dev": true
+				}
+			}
+		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -3838,6 +4715,12 @@
 			"requires": {
 				"flat-cache": "^2.0.1"
 			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true
 		},
 		"filename-regex": {
 			"version": "2.0.1",
@@ -4019,6 +4902,12 @@
 				"for-in": "^1.0.1"
 			}
 		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
+		},
 		"foreground-child": {
 			"version": "1.5.6",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
@@ -4065,6 +4954,12 @@
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+			"dev": true
 		},
 		"fs-constants": {
 			"version": "1.0.0",
@@ -4728,6 +5623,12 @@
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
 			"dev": true
 		},
+		"get-port": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+			"dev": true
+		},
 		"get-stdin": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -4928,6 +5829,16 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
 			"integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw=="
 		},
+		"grapheme-breaker": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/grapheme-breaker/-/grapheme-breaker-0.3.2.tgz",
+			"integrity": "sha1-W55reMODJFLSuiuxy4MPlidkEKw=",
+			"dev": true,
+			"requires": {
+				"brfs": "^1.2.0",
+				"unicode-trie": "^0.3.1"
+			}
+		},
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -4942,26 +5853,6 @@
 			"requires": {
 				"duplexer": "^0.1.1",
 				"pify": "^4.0.1"
-			}
-		},
-		"handlebars": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-			"integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
-			"dev": true,
-			"requires": {
-				"neo-async": "^2.6.0",
-				"optimist": "^0.6.1",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"har-schema": {
@@ -5059,6 +5950,26 @@
 			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
 			"dev": true
 		},
+		"hash-base": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
 		"hasha": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
@@ -5079,6 +5990,17 @@
 			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
 			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
 			"dev": true
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"dev": true,
+			"requires": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
 		},
 		"hosted-git-info": {
 			"version": "2.7.1",
@@ -5102,6 +6024,112 @@
 			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
 			"integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
 			"dev": true
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"dev": true,
+			"requires": {
+				"whatwg-encoding": "^1.0.1"
+			}
+		},
+		"html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true
+		},
+		"html-tags": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.2.0.tgz",
+			"integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g=",
+			"dev": true
+		},
+		"htmlnano": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-0.2.5.tgz",
+			"integrity": "sha512-X1iPSwXG/iF9bVs+/obt2n6F64uH0ETkA8zp7qFDmLW9/+A6ueHGeb/+qD67T21qUY22owZPMdawljN50ajkqA==",
+			"dev": true,
+			"requires": {
+				"cssnano": "^4.1.10",
+				"normalize-html-whitespace": "^1.0.0",
+				"posthtml": "^0.12.0",
+				"posthtml-render": "^1.1.5",
+				"purgecss": "^1.4.0",
+				"svgo": "^1.3.2",
+				"terser": "^4.3.9",
+				"uncss": "^0.17.2"
+			},
+			"dependencies": {
+				"css-tree": {
+					"version": "1.0.0-alpha.37",
+					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+					"integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+					"dev": true,
+					"requires": {
+						"mdn-data": "2.0.4",
+						"source-map": "^0.6.1"
+					}
+				},
+				"csso": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/csso/-/csso-4.0.2.tgz",
+					"integrity": "sha512-kS7/oeNVXkHWxby5tHVxlhjizRCSv8QdU7hB2FpdAibDU8FjTAolhNjKNTiLzXtUrKT6HwClE81yXwEk1309wg==",
+					"dev": true,
+					"requires": {
+						"css-tree": "1.0.0-alpha.37"
+					}
+				},
+				"posthtml": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.12.0.tgz",
+					"integrity": "sha512-aNUEP/SfKUXAt+ghG51LC5MmafChBZeslVe/SSdfKIgLGUVRE68mrMF4V8XbH07ZifM91tCSuxY3eHIFLlecQw==",
+					"dev": true,
+					"requires": {
+						"posthtml-parser": "^0.4.1",
+						"posthtml-render": "^1.1.5"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"svgo": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+					"integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.1",
+						"coa": "^2.0.2",
+						"css-select": "^2.0.0",
+						"css-select-base-adapter": "^0.1.1",
+						"css-tree": "1.0.0-alpha.37",
+						"csso": "^4.0.2",
+						"js-yaml": "^3.13.1",
+						"mkdirp": "~0.5.1",
+						"object.values": "^1.1.0",
+						"sax": "~1.2.4",
+						"stable": "^0.1.8",
+						"unquote": "~1.1.1",
+						"util.promisify": "~1.0.0"
+					}
+				},
+				"terser": {
+					"version": "4.4.2",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.4.2.tgz",
+					"integrity": "sha512-Uufrsvhj9O1ikwgITGsZ5EZS6qPokUOkCegS7fYOdGTv+OA90vndUbU6PEjr5ePqHfNUbGyMO7xyIZv2MhsALQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.20.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.12"
+					}
+				}
+			}
 		},
 		"htmlparser2": {
 			"version": "3.10.1",
@@ -5136,6 +6164,19 @@
 			"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
 			"dev": true
 		},
+		"http-errors": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+			"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+			"dev": true,
+			"requires": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.4",
+				"setprototypeof": "1.1.1",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.0"
+			}
+		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -5146,6 +6187,12 @@
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
 			}
+		},
+		"https-browserify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+			"dev": true
 		},
 		"iconv-lite": {
 			"version": "0.4.24",
@@ -5160,6 +6207,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
 			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+			"dev": true
+		},
+		"ieee754": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
 			"dev": true
 		},
 		"ignore": {
@@ -5465,6 +6518,15 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-html": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-html/-/is-html-1.1.0.tgz",
+			"integrity": "sha1-4E8cGNOUhRETlvmgJz6rUa8hhGQ=",
+			"dev": true,
+			"requires": {
+				"html-tags": "^1.0.0"
+			}
+		},
 		"is-installed-globally": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
@@ -5649,6 +6711,12 @@
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
 		},
+		"is-url": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+			"dev": true
+		},
 		"is-url-superb": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-3.0.0.tgz",
@@ -5662,6 +6730,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -5808,12 +6882,12 @@
 			}
 		},
 		"istanbul-reports": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-			"integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+			"integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
 			"dev": true,
 			"requires": {
-				"handlebars": "^4.1.2"
+				"html-escaper": "^2.0.0"
 			}
 		},
 		"jest-worker": {
@@ -5858,6 +6932,87 @@
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 			"dev": true
+		},
+		"jsdom": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-14.1.0.tgz",
+			"integrity": "sha512-O901mfJSuTdwU2w3Sn+74T+RnDVP+FuV5fH8tcPWyqrseRAb0s5xOtPgCFiPOtLcyK7CLIJwPyD83ZqQWvA5ng==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"acorn": "^6.0.4",
+				"acorn-globals": "^4.3.0",
+				"array-equal": "^1.0.0",
+				"cssom": "^0.3.4",
+				"cssstyle": "^1.1.1",
+				"data-urls": "^1.1.0",
+				"domexception": "^1.0.1",
+				"escodegen": "^1.11.0",
+				"html-encoding-sniffer": "^1.0.2",
+				"nwsapi": "^2.1.3",
+				"parse5": "5.1.0",
+				"pn": "^1.1.0",
+				"request": "^2.88.0",
+				"request-promise-native": "^1.0.5",
+				"saxes": "^3.1.9",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.5.0",
+				"w3c-hr-time": "^1.0.1",
+				"w3c-xmlserializer": "^1.1.2",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.5",
+				"whatwg-mimetype": "^2.3.0",
+				"whatwg-url": "^7.0.0",
+				"ws": "^6.1.2",
+				"xml-name-validator": "^3.0.0"
+			},
+			"dependencies": {
+				"escodegen": {
+					"version": "1.12.0",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+					"integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+					"dev": true,
+					"requires": {
+						"esprima": "^3.1.3",
+						"estraverse": "^4.2.0",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.6.1"
+					}
+				},
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
+					"optional": true
+				},
+				"tough-cookie": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
+					}
+				},
+				"ws": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
+			}
 		},
 		"jsesc": {
 			"version": "2.5.2",
@@ -5910,9 +7065,9 @@
 			},
 			"dependencies": {
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				}
 			}
@@ -5970,9 +7125,9 @@
 			}
 		},
 		"kind-of": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
 		},
 		"latest-version": {
 			"version": "3.1.0",
@@ -6257,6 +7412,12 @@
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
 			"dev": true
 		},
+		"lodash.clone": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
+			"dev": true
+		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -6273,6 +7434,12 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+			"dev": true
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
 		"lodash.sumby": {
@@ -6533,6 +7700,17 @@
 				}
 			}
 		},
+		"md5.js": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"dev": true,
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
 		"mdn-data": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -6680,6 +7858,22 @@
 				"to-regex": "^3.0.2"
 			}
 		},
+		"miller-rabin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.0.0",
+				"brorand": "^1.0.1"
+			}
+		},
+		"mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true
+		},
 		"mime-db": {
 			"version": "1.40.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -6705,6 +7899,18 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
 			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true
+		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"dev": true
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
 			"dev": true
 		},
 		"minimatch": {
@@ -7073,12 +8279,6 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
-		"neo-async": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-			"dev": true
-		},
 		"nested-error-stacks": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
@@ -7121,6 +8321,12 @@
 				"semver": "^5.4.1"
 			}
 		},
+		"node-addon-api": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
+			"integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
+			"dev": true
+		},
 		"node-environment-flags": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -7129,6 +8335,51 @@
 			"requires": {
 				"object.getownpropertydescriptors": "^2.0.3",
 				"semver": "^5.7.0"
+			}
+		},
+		"node-forge": {
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+			"integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==",
+			"dev": true
+		},
+		"node-libs-browser": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+			"integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
+			"dev": true,
+			"requires": {
+				"assert": "^1.1.1",
+				"browserify-zlib": "^0.2.0",
+				"buffer": "^4.3.0",
+				"console-browserify": "^1.1.0",
+				"constants-browserify": "^1.0.0",
+				"crypto-browserify": "^3.11.0",
+				"domain-browser": "^1.1.1",
+				"events": "^3.0.0",
+				"https-browserify": "^1.0.0",
+				"os-browserify": "^0.3.0",
+				"path-browserify": "0.0.1",
+				"process": "^0.11.10",
+				"punycode": "^1.2.4",
+				"querystring-es3": "^0.2.0",
+				"readable-stream": "^2.3.3",
+				"stream-browserify": "^2.0.1",
+				"stream-http": "^2.7.2",
+				"string_decoder": "^1.0.0",
+				"timers-browserify": "^2.0.4",
+				"tty-browserify": "0.0.0",
+				"url": "^0.11.0",
+				"util": "^0.11.0",
+				"vm-browserify": "^1.0.1"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				}
 			}
 		},
 		"node-releases": {
@@ -7189,6 +8440,12 @@
 			"requires": {
 				"abbrev": "1"
 			}
+		},
+		"normalize-html-whitespace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-html-whitespace/-/normalize-html-whitespace-1.0.0.tgz",
+			"integrity": "sha512-9ui7CGtOOlehQu0t/OhhlmDyc71mKVlv+4vF+me4iZLPrNtRL2xoquEdfZxasC/bdQi/Hr3iTrpyRKIG+ocabA==",
+			"dev": true
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -7474,6 +8731,12 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
 		},
+		"nwsapi": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+			"dev": true
+		},
 		"nyc": {
 			"version": "14.1.1",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
@@ -7618,6 +8881,12 @@
 				}
 			}
 		},
+		"object-inspect": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
+			"integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw==",
+			"dev": true
+		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -7708,6 +8977,15 @@
 				"has": "^1.0.3"
 			}
 		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"dev": true,
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7725,22 +9003,13 @@
 				"mimic-fn": "^1.0.0"
 			}
 		},
-		"optimist": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+		"opn": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+			"integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
 			"dev": true,
 			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
-			},
-			"dependencies": {
-				"wordwrap": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-					"dev": true
-				}
+				"is-wsl": "^1.1.0"
 			}
 		},
 		"optionator": {
@@ -7756,6 +9025,37 @@
 				"type-check": "~0.3.2",
 				"wordwrap": "~1.0.0"
 			}
+		},
+		"ora": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-2.1.0.tgz",
+			"integrity": "sha512-hNNlAd3gfv/iPmsNxYoAPLvxg7HuPozww7fFonMZvL84tP6Ox5igfk5j/+a9rtJJwqMgKK+JgWsAQik5o0HTLA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.3.1",
+				"cli-cursor": "^2.1.0",
+				"cli-spinners": "^1.1.0",
+				"log-symbols": "^2.2.0",
+				"strip-ansi": "^4.0.0",
+				"wcwidth": "^1.0.1"
+			},
+			"dependencies": {
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"os-browserify": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+			"dev": true
 		},
 		"os-homedir": {
 			"version": "1.0.2",
@@ -7779,17 +9079,6 @@
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
-		},
-		"output-file-sync": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-2.0.1.tgz",
-			"integrity": "sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.11",
-				"is-plain-obj": "^1.1.0",
-				"mkdirp": "^0.5.1"
-			}
 		},
 		"p-cancelable": {
 			"version": "1.1.0",
@@ -7881,6 +9170,1515 @@
 				"semver": "^5.1.0"
 			}
 		},
+		"pako": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+			"dev": true
+		},
+		"parcel-bundler": {
+			"version": "1.12.4",
+			"resolved": "https://registry.npmjs.org/parcel-bundler/-/parcel-bundler-1.12.4.tgz",
+			"integrity": "sha512-G+iZGGiPEXcRzw0fiRxWYCKxdt/F7l9a0xkiU4XbcVRJCSlBnioWEwJMutOCCpoQmaQtjB4RBHDGIHN85AIhLQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/core": "^7.4.4",
+				"@babel/generator": "^7.4.4",
+				"@babel/parser": "^7.4.4",
+				"@babel/plugin-transform-flow-strip-types": "^7.4.4",
+				"@babel/plugin-transform-modules-commonjs": "^7.4.4",
+				"@babel/plugin-transform-react-jsx": "^7.0.0",
+				"@babel/preset-env": "^7.4.4",
+				"@babel/runtime": "^7.4.4",
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4",
+				"@iarna/toml": "^2.2.0",
+				"@parcel/fs": "^1.11.0",
+				"@parcel/logger": "^1.11.1",
+				"@parcel/utils": "^1.11.0",
+				"@parcel/watcher": "^1.12.1",
+				"@parcel/workers": "^1.11.0",
+				"ansi-to-html": "^0.6.4",
+				"babylon-walk": "^1.0.2",
+				"browserslist": "^4.1.0",
+				"chalk": "^2.1.0",
+				"clone": "^2.1.1",
+				"command-exists": "^1.2.6",
+				"commander": "^2.11.0",
+				"core-js": "^2.6.5",
+				"cross-spawn": "^6.0.4",
+				"css-modules-loader-core": "^1.1.0",
+				"cssnano": "^4.0.0",
+				"deasync": "^0.1.14",
+				"dotenv": "^5.0.0",
+				"dotenv-expand": "^5.1.0",
+				"envinfo": "^7.3.1",
+				"fast-glob": "^2.2.2",
+				"filesize": "^3.6.0",
+				"get-port": "^3.2.0",
+				"htmlnano": "^0.2.2",
+				"is-glob": "^4.0.0",
+				"is-url": "^1.2.2",
+				"js-yaml": "^3.10.0",
+				"json5": "^1.0.1",
+				"micromatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"node-forge": "^0.7.1",
+				"node-libs-browser": "^2.0.0",
+				"opn": "^5.1.0",
+				"postcss": "^7.0.11",
+				"postcss-value-parser": "^3.3.1",
+				"posthtml": "^0.11.2",
+				"posthtml-parser": "^0.4.0",
+				"posthtml-render": "^1.1.3",
+				"resolve": "^1.4.0",
+				"semver": "^5.4.1",
+				"serialize-to-js": "^3.0.0",
+				"serve-static": "^1.12.4",
+				"source-map": "0.6.1",
+				"terser": "^3.7.3",
+				"v8-compile-cache": "^2.0.0",
+				"ws": "^5.1.1"
+			},
+			"dependencies": {
+				"@babel/core": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.5.tgz",
+					"integrity": "sha512-M42+ScN4+1S9iB6f+TL7QBpoQETxbclx+KNoKJABghnKYE+fMzSGqst0BZJc8CpI625bwPwYgUyRvxZ+0mZzpw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helpers": "^7.7.4",
+						"@babel/parser": "^7.7.5",
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"json5": "^2.1.0",
+						"lodash": "^4.17.13",
+						"resolve": "^1.3.2",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
+					},
+					"dependencies": {
+						"@babel/generator": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+							"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.7.4",
+								"jsesc": "^2.5.1",
+								"lodash": "^4.17.13",
+								"source-map": "^0.5.0"
+							}
+						},
+						"@babel/parser": {
+							"version": "7.7.5",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+							"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+							"dev": true
+						},
+						"@babel/template": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+							"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.0.0",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4"
+							}
+						},
+						"@babel/traverse": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+							"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.5.5",
+								"@babel/generator": "^7.7.4",
+								"@babel/helper-function-name": "^7.7.4",
+								"@babel/helper-split-export-declaration": "^7.7.4",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4",
+								"debug": "^4.1.0",
+								"globals": "^11.1.0",
+								"lodash": "^4.17.13"
+							}
+						},
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						},
+						"json5": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+							"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+							"dev": true,
+							"requires": {
+								"minimist": "^1.2.0"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
+					"integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-builder-binary-assignment-operator-visitor": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz",
+					"integrity": "sha512-Biq/d/WtvfftWZ9Uf39hbPBYDUo986m5Bb4zhkeYDGUllF43D+nUe5M6Vuo6/8JDK/0YX/uBdeoQpyaNhNugZQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-explode-assignable-expression": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-call-delegate": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz",
+					"integrity": "sha512-8JH9/B7J7tCYJ2PpWVpw9JhPuEVHztagNVuQAFBVFYluRMlpG7F1CgKEgGeL6KFqcsIa92ZYVj6DSc0XwmN1ZA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/generator": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+							"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.7.4",
+								"jsesc": "^2.5.1",
+								"lodash": "^4.17.13",
+								"source-map": "^0.5.0"
+							}
+						},
+						"@babel/parser": {
+							"version": "7.7.5",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+							"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+							"dev": true
+						},
+						"@babel/traverse": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+							"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.5.5",
+								"@babel/generator": "^7.7.4",
+								"@babel/helper-function-name": "^7.7.4",
+								"@babel/helper-split-export-declaration": "^7.7.4",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4",
+								"debug": "^4.1.0",
+								"globals": "^11.1.0",
+								"lodash": "^4.17.13"
+							}
+						},
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/helper-define-map": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz",
+					"integrity": "sha512-v5LorqOa0nVQUvAUTUF3KPastvUt/HzByXNamKQ6RdJRTV7j8rLL+WB5C/MzzWAwOomxDhYFb1wLLxHqox86lg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-explode-assignable-expression": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
+					"integrity": "sha512-2/SicuFrNSXsZNBxe5UGdLr+HZg+raWBLE9vC98bdYOKX/U6PY0mdGlYUJdtTDPSU0Lw0PNbKKDpwYHJLn2jLg==",
+					"dev": true,
+					"requires": {
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/generator": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+							"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.7.4",
+								"jsesc": "^2.5.1",
+								"lodash": "^4.17.13",
+								"source-map": "^0.5.0"
+							}
+						},
+						"@babel/parser": {
+							"version": "7.7.5",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+							"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+							"dev": true
+						},
+						"@babel/traverse": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+							"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.5.5",
+								"@babel/generator": "^7.7.4",
+								"@babel/helper-function-name": "^7.7.4",
+								"@babel/helper-split-export-declaration": "^7.7.4",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4",
+								"debug": "^4.1.0",
+								"globals": "^11.1.0",
+								"lodash": "^4.17.13"
+							}
+						},
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/parser": {
+							"version": "7.7.5",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+							"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+							"dev": true
+						},
+						"@babel/template": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+							"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.0.0",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4"
+							}
+						},
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz",
+					"integrity": "sha512-wQC4xyvc1Jo/FnLirL6CEgPgPCa8M74tOdjWpRhQYapz5JC7u3NYU1zCVoVAGCE3EaIP9T1A3iW0WLJ+reZlpQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
+					"integrity": "sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
+					"integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.5.tgz",
+					"integrity": "sha512-A7pSxyJf1gN5qXVcidwLWydjftUN878VkalhXX5iQDuGyiGK3sOrrKKHF4/A4fwHtnsotv/NipwAeLzY4KQPvw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.7.4",
+						"@babel/helper-simple-access": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"@babel/parser": {
+							"version": "7.7.5",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+							"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+							"dev": true
+						},
+						"@babel/template": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+							"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.0.0",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4"
+							}
+						},
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
+					"integrity": "sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-remap-async-to-generator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
+					"integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.7.4",
+						"@babel/helper-wrap-function": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/generator": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+							"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.7.4",
+								"jsesc": "^2.5.1",
+								"lodash": "^4.17.13",
+								"source-map": "^0.5.0"
+							}
+						},
+						"@babel/parser": {
+							"version": "7.7.5",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+							"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+							"dev": true
+						},
+						"@babel/template": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+							"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.0.0",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4"
+							}
+						},
+						"@babel/traverse": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+							"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.5.5",
+								"@babel/generator": "^7.7.4",
+								"@babel/helper-function-name": "^7.7.4",
+								"@babel/helper-split-export-declaration": "^7.7.4",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4",
+								"debug": "^4.1.0",
+								"globals": "^11.1.0",
+								"lodash": "^4.17.13"
+							}
+						},
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
+					"integrity": "sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.7.4",
+						"@babel/helper-optimise-call-expression": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/generator": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+							"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.7.4",
+								"jsesc": "^2.5.1",
+								"lodash": "^4.17.13",
+								"source-map": "^0.5.0"
+							}
+						},
+						"@babel/parser": {
+							"version": "7.7.5",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+							"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+							"dev": true
+						},
+						"@babel/traverse": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+							"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.5.5",
+								"@babel/generator": "^7.7.4",
+								"@babel/helper-function-name": "^7.7.4",
+								"@babel/helper-split-export-declaration": "^7.7.4",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4",
+								"debug": "^4.1.0",
+								"globals": "^11.1.0",
+								"lodash": "^4.17.13"
+							}
+						},
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
+					"integrity": "sha512-zK7THeEXfan7UlWsG2A6CI/L9jVnI5+xxKZOdej39Y0YtDYKx9raHk5F2EtK9K8DHRTihYwg20ADt9S36GR78A==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/parser": {
+							"version": "7.7.5",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+							"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+							"dev": true
+						},
+						"@babel/template": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+							"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.0.0",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4"
+							}
+						},
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-wrap-function": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
+					"integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/generator": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+							"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.7.4",
+								"jsesc": "^2.5.1",
+								"lodash": "^4.17.13",
+								"source-map": "^0.5.0"
+							}
+						},
+						"@babel/parser": {
+							"version": "7.7.5",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+							"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+							"dev": true
+						},
+						"@babel/template": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+							"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.0.0",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4"
+							}
+						},
+						"@babel/traverse": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+							"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.5.5",
+								"@babel/generator": "^7.7.4",
+								"@babel/helper-function-name": "^7.7.4",
+								"@babel/helper-split-export-declaration": "^7.7.4",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4",
+								"debug": "^4.1.0",
+								"globals": "^11.1.0",
+								"lodash": "^4.17.13"
+							}
+						},
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/helpers": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
+					"integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					},
+					"dependencies": {
+						"@babel/generator": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+							"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.7.4",
+								"jsesc": "^2.5.1",
+								"lodash": "^4.17.13",
+								"source-map": "^0.5.0"
+							}
+						},
+						"@babel/parser": {
+							"version": "7.7.5",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+							"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+							"dev": true
+						},
+						"@babel/template": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+							"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.0.0",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4"
+							}
+						},
+						"@babel/traverse": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+							"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.5.5",
+								"@babel/generator": "^7.7.4",
+								"@babel/helper-function-name": "^7.7.4",
+								"@babel/helper-split-export-declaration": "^7.7.4",
+								"@babel/parser": "^7.7.4",
+								"@babel/types": "^7.7.4",
+								"debug": "^4.1.0",
+								"globals": "^11.1.0",
+								"lodash": "^4.17.13"
+							}
+						},
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/plugin-proposal-async-generator-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
+					"integrity": "sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-remap-async-to-generator": "^7.7.4",
+						"@babel/plugin-syntax-async-generators": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-json-strings": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
+					"integrity": "sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-json-strings": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
+					"integrity": "sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-optional-catch-binding": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
+					"integrity": "sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-unicode-property-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.4.tgz",
+					"integrity": "sha512-cHgqHgYvffluZk85dJ02vloErm3Y6xtH+2noOBOJ2kXOJH3aVCDnj5eR/lVNlTnYu4hndAPJD3rTFjW3qee0PA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-async-generators": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
+					"integrity": "sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-json-strings": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
+					"integrity": "sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-object-rest-spread": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
+					"integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-optional-catch-binding": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
+					"integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-arrow-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
+					"integrity": "sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-async-to-generator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
+					"integrity": "sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-remap-async-to-generator": "^7.7.4"
+					}
+				},
+				"@babel/plugin-transform-block-scoped-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
+					"integrity": "sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-block-scoping": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
+					"integrity": "sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/plugin-transform-classes": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz",
+					"integrity": "sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.7.4",
+						"@babel/helper-define-map": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-optimise-call-expression": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/plugin-transform-computed-properties": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz",
+					"integrity": "sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz",
+					"integrity": "sha512-4jFMXI1Cu2aXbcXXl8Lr6YubCn6Oc7k9lLsu8v61TZh+1jny2BWmdtvY9zSUlLdGUvcy9DMAWyZEOqjsbeg/wA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-dotall-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.4.tgz",
+					"integrity": "sha512-mk0cH1zyMa/XHeb6LOTXTbG7uIJ8Rrjlzu91pUx/KS3JpcgaTDwMS8kM+ar8SLOvlL2Lofi4CGBAjCo3a2x+lw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-duplicate-keys": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
+					"integrity": "sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-exponentiation-operator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
+					"integrity": "sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-for-of": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz",
+					"integrity": "sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz",
+					"integrity": "sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-literals": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz",
+					"integrity": "sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-member-expression-literals": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz",
+					"integrity": "sha512-9VMwMO7i69LHTesL0RdGy93JU6a+qOPuvB4F4d0kR0zyVjJRVJRaoaGjhtki6SzQUu8yen/vxPKN6CWnCUw6bA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-modules-amd": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.5.tgz",
+					"integrity": "sha512-CT57FG4A2ZUNU1v+HdvDSDrjNWBrtCmSH6YbbgN3Lrf0Di/q/lWRxZrE72p3+HCCz9UjfZOEBdphgC0nzOS6DQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.7.5",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"babel-plugin-dynamic-import-node": "^2.3.0"
+					}
+				},
+				"@babel/plugin-transform-modules-systemjs": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
+					"integrity": "sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"babel-plugin-dynamic-import-node": "^2.3.0"
+					}
+				},
+				"@babel/plugin-transform-modules-umd": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
+					"integrity": "sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-named-capturing-groups-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz",
+					"integrity": "sha512-jBUkiqLKvUWpv9GLSuHUFYdmHg0ujC1JEYoZUfeOOfNydZXp1sXObgyPatpcwjWgsdBGsagWW0cdJpX/DO2jMw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.7.4"
+					}
+				},
+				"@babel/plugin-transform-new-target": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
+					"integrity": "sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-object-super": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
+					"integrity": "sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.7.4"
+					}
+				},
+				"@babel/plugin-transform-parameters": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.4.tgz",
+					"integrity": "sha512-VJwhVePWPa0DqE9vcfptaJSzNDKrWU/4FbYCjZERtmqEs05g3UMXnYMZoXja7JAJ7Y7sPZipwm/pGApZt7wHlw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-call-delegate": "^7.7.4",
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-property-literals": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz",
+					"integrity": "sha512-MatJhlC4iHsIskWYyawl53KuHrt+kALSADLQQ/HkhTjX954fkxIEh4q5slL4oRAnsm/eDoZ4q0CIZpcqBuxhJQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-regenerator": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.5.tgz",
+					"integrity": "sha512-/8I8tPvX2FkuEyWbjRCt4qTAgZK0DVy8QRguhA524UH48RfGJy94On2ri+dCuwOpcerPRl9O4ebQkRcVzIaGBw==",
+					"dev": true,
+					"requires": {
+						"regenerator-transform": "^0.14.0"
+					}
+				},
+				"@babel/plugin-transform-reserved-words": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.7.4.tgz",
+					"integrity": "sha512-OrPiUB5s5XvkCO1lS7D8ZtHcswIC57j62acAnJZKqGGnHP+TIc/ljQSrgdX/QyOTdEK5COAhuc820Hi1q2UgLQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-shorthand-properties": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz",
+					"integrity": "sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-spread": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz",
+					"integrity": "sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-sticky-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz",
+					"integrity": "sha512-Ls2NASyL6qtVe1H1hXts9yuEeONV2TJZmplLONkMPUG158CtmnrzW5Q5teibM5UVOFjG0D3IC5mzXR6pPpUY7A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-regex": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-template-literals": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz",
+					"integrity": "sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-typeof-symbol": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
+					"integrity": "sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-unicode-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz",
+					"integrity": "sha512-N77UUIV+WCvE+5yHw+oks3m18/umd7y392Zv7mYTpFqHtkpcc+QUz+gLJNTWVlWROIWeLqY0f3OjZxV5TcXnRw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/preset-env": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.6.tgz",
+					"integrity": "sha512-k5hO17iF/Q7tR9Jv8PdNBZWYW6RofxhnxKjBMc0nG4JTaWvOTiPoO/RLFwAKcA4FpmuBFm6jkoqaRJLGi0zdaQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-proposal-async-generator-functions": "^7.7.4",
+						"@babel/plugin-proposal-dynamic-import": "^7.7.4",
+						"@babel/plugin-proposal-json-strings": "^7.7.4",
+						"@babel/plugin-proposal-object-rest-spread": "^7.7.4",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.7.4",
+						"@babel/plugin-syntax-async-generators": "^7.7.4",
+						"@babel/plugin-syntax-dynamic-import": "^7.7.4",
+						"@babel/plugin-syntax-json-strings": "^7.7.4",
+						"@babel/plugin-syntax-object-rest-spread": "^7.7.4",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
+						"@babel/plugin-syntax-top-level-await": "^7.7.4",
+						"@babel/plugin-transform-arrow-functions": "^7.7.4",
+						"@babel/plugin-transform-async-to-generator": "^7.7.4",
+						"@babel/plugin-transform-block-scoped-functions": "^7.7.4",
+						"@babel/plugin-transform-block-scoping": "^7.7.4",
+						"@babel/plugin-transform-classes": "^7.7.4",
+						"@babel/plugin-transform-computed-properties": "^7.7.4",
+						"@babel/plugin-transform-destructuring": "^7.7.4",
+						"@babel/plugin-transform-dotall-regex": "^7.7.4",
+						"@babel/plugin-transform-duplicate-keys": "^7.7.4",
+						"@babel/plugin-transform-exponentiation-operator": "^7.7.4",
+						"@babel/plugin-transform-for-of": "^7.7.4",
+						"@babel/plugin-transform-function-name": "^7.7.4",
+						"@babel/plugin-transform-literals": "^7.7.4",
+						"@babel/plugin-transform-member-expression-literals": "^7.7.4",
+						"@babel/plugin-transform-modules-amd": "^7.7.5",
+						"@babel/plugin-transform-modules-commonjs": "^7.7.5",
+						"@babel/plugin-transform-modules-systemjs": "^7.7.4",
+						"@babel/plugin-transform-modules-umd": "^7.7.4",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
+						"@babel/plugin-transform-new-target": "^7.7.4",
+						"@babel/plugin-transform-object-super": "^7.7.4",
+						"@babel/plugin-transform-parameters": "^7.7.4",
+						"@babel/plugin-transform-property-literals": "^7.7.4",
+						"@babel/plugin-transform-regenerator": "^7.7.5",
+						"@babel/plugin-transform-reserved-words": "^7.7.4",
+						"@babel/plugin-transform-shorthand-properties": "^7.7.4",
+						"@babel/plugin-transform-spread": "^7.7.4",
+						"@babel/plugin-transform-sticky-regex": "^7.7.4",
+						"@babel/plugin-transform-template-literals": "^7.7.4",
+						"@babel/plugin-transform-typeof-symbol": "^7.7.4",
+						"@babel/plugin-transform-unicode-regex": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"browserslist": "^4.6.0",
+						"core-js-compat": "^3.4.7",
+						"invariant": "^2.2.2",
+						"js-levenshtein": "^1.1.3",
+						"semver": "^5.5.0"
+					},
+					"dependencies": {
+						"@babel/plugin-transform-modules-commonjs": {
+							"version": "7.7.5",
+							"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz",
+							"integrity": "sha512-9Cq4zTFExwFhQI6MT1aFxgqhIsMWQWDVwOgLzl7PTWJHsNaqFvklAU+Oz6AQLAS0dJKTwZSOCo20INwktxpi3Q==",
+							"dev": true,
+							"requires": {
+								"@babel/helper-module-transforms": "^7.7.5",
+								"@babel/helper-plugin-utils": "^7.0.0",
+								"@babel/helper-simple-access": "^7.7.4",
+								"babel-plugin-dynamic-import-node": "^2.3.0"
+							}
+						},
+						"@babel/types": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+							"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001015",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+					"integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
+					"dev": true
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"convert-source-map": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+					"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.1"
+					}
+				},
+				"core-js-compat": {
+					"version": "3.4.8",
+					"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.8.tgz",
+					"integrity": "sha512-l3WTmnXHV2Sfu5VuD7EHE2w7y+K68+kULKt5RJg8ZJk3YhHF1qLD4O8v8AmNq+8vbOwnPFFDvds25/AoEvMqlQ==",
+					"dev": true,
+					"requires": {
+						"browserslist": "^4.8.2",
+						"semver": "^6.3.0"
+					},
+					"dependencies": {
+						"browserslist": {
+							"version": "4.8.2",
+							"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+							"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+							"dev": true,
+							"requires": {
+								"caniuse-lite": "^1.0.30001015",
+								"electron-to-chromium": "^1.3.322",
+								"node-releases": "^1.1.42"
+							}
+						},
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+							"dev": true
+						}
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"dotenv": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+					"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.322",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+					"integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"node-releases": {
+					"version": "1.1.42",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+					"integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.3.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+							"dev": true
+						}
+					}
+				},
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
 		"parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7888,6 +10686,20 @@
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
+			}
+		},
+		"parse-asn1": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+			"dev": true,
+			"requires": {
+				"asn1.js": "^4.0.0",
+				"browserify-aes": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"parse-dotenv": {
@@ -7933,10 +10745,28 @@
 				"json-parse-better-errors": "^1.0.1"
 			}
 		},
+		"parse5": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+			"dev": true
+		},
+		"parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"dev": true
+		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
 			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+		},
+		"path-browserify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+			"dev": true
 		},
 		"path-dirname": {
 			"version": "1.0.2",
@@ -8008,10 +10838,29 @@
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
 			"dev": true
 		},
+		"pbkdf2": {
+			"version": "3.0.17",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+			"dev": true,
+			"requires": {
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
+		},
+		"physical-cpu-count": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz",
+			"integrity": "sha1-GN4vl+S/epVRrXURlCtUlverpmA=",
 			"dev": true
 		},
 		"pidtree": {
@@ -8040,6 +10889,67 @@
 				"pinkie": "^2.0.0"
 			}
 		},
+		"pkg-conf": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+			"integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+			"requires": {
+				"find-up": "^3.0.0",
+				"load-json-file": "^5.2.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+					"integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+					"requires": {
+						"graceful-fs": "^4.1.15",
+						"parse-json": "^4.0.0",
+						"pify": "^4.0.1",
+						"strip-bom": "^3.0.0",
+						"type-fest": "^0.3.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+					"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+				}
+			}
+		},
 		"pkg-dir": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
@@ -8048,6 +10958,12 @@
 			"requires": {
 				"find-up": "^2.1.0"
 			}
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
@@ -8366,9 +11282,9 @@
 					}
 				},
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				},
 				"parse-json": {
@@ -8408,9 +11324,9 @@
 					}
 				},
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				},
 				"parse-json": {
@@ -8450,9 +11366,9 @@
 					}
 				},
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				},
 				"parse-json": {
@@ -9251,6 +12167,31 @@
 				}
 			}
 		},
+		"posthtml": {
+			"version": "0.11.6",
+			"resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.11.6.tgz",
+			"integrity": "sha512-C2hrAPzmRdpuL3iH0TDdQ6XCc9M7Dcc3zEW5BLerY65G4tWWszwv6nG/ksi6ul5i2mx22ubdljgktXCtNkydkw==",
+			"dev": true,
+			"requires": {
+				"posthtml-parser": "^0.4.1",
+				"posthtml-render": "^1.1.5"
+			}
+		},
+		"posthtml-parser": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.4.2.tgz",
+			"integrity": "sha512-BUIorsYJTvS9UhXxPTzupIztOMVNPa/HtAm9KHni9z6qEfiJ1bpOBL5DfUOL9XAc3XkLIEzBzpph+Zbm4AdRAg==",
+			"dev": true,
+			"requires": {
+				"htmlparser2": "^3.9.2"
+			}
+		},
+		"posthtml-render": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.1.5.tgz",
+			"integrity": "sha512-yvt54j0zCBHQVEFAuR+yHld8CZrCa/E1Z/OcFNCV1IEWTLVxT8O7nYnM4IIw1CD4r8kaRd3lc42+0lgCKgm87w==",
+			"dev": true
+		},
 		"prebuild-install": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.0.tgz",
@@ -9276,9 +12217,9 @@
 			},
 			"dependencies": {
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				}
 			}
@@ -9328,6 +12269,12 @@
 			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
 			"dev": true
 		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+			"dev": true
+		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -9375,6 +12322,20 @@
 			"integrity": "sha512-xsMgrUwRpuGskEzBFkH8NmTimbZ5PcPup0LA8JJkHIm2IMUbQcpo3yeLNWVrufEYjh8YwtSVh0xz6UeWc5Oh5A==",
 			"dev": true
 		},
+		"public-encrypt": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.0",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"parse-asn1": "^5.0.0",
+				"randombytes": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
 		"pump": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -9390,6 +12351,126 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
+		},
+		"purgecss": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/purgecss/-/purgecss-1.4.1.tgz",
+			"integrity": "sha512-5jONV/D/3nfa+lC425+LA+OWe5/LDn4a79cac+TnzJq3VczwnWlpIDdW275hHsGhkzIlqATQsYFLW7or0cSwNQ==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3",
+				"postcss": "^7.0.14",
+				"postcss-selector-parser": "^6.0.0",
+				"yargs": "^14.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"cssesc": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+					"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"postcss-selector-parser": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+					"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+					"dev": true,
+					"requires": {
+						"cssesc": "^3.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"yargs": {
+					"version": "14.2.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz",
+					"integrity": "sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^15.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "15.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+					"integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
 		},
 		"q": {
 			"version": "1.5.1",
@@ -9413,10 +12494,41 @@
 				"strict-uri-encode": "^1.0.0"
 			}
 		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+			"dev": true
+		},
+		"querystring-es3": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+			"dev": true
+		},
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
 			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
+		},
+		"quote-stream": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
+			"integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
+			"dev": true,
+			"requires": {
+				"buffer-equal": "0.0.1",
+				"minimist": "^1.1.3",
+				"through2": "^2.0.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				}
+			}
 		},
 		"randomatic": {
 			"version": "3.1.1",
@@ -9437,6 +12549,31 @@
 				}
 			}
 		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.0.5",
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"dev": true
+		},
 		"rc": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -9450,9 +12587,9 @@
 			},
 			"dependencies": {
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				}
 			}
@@ -9722,6 +12859,26 @@
 				"uuid": "^3.3.2"
 			}
 		},
+		"request-promise-core": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+			"integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.15"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+			"integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+			"dev": true,
+			"requires": {
+				"request-promise-core": "1.1.3",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
+			}
+		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9808,6 +12965,16 @@
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
+			}
+		},
+		"ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"dev": true,
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"rollup": {
@@ -11509,6 +14676,15 @@
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 			"dev": true
 		},
+		"saxes": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+			"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+			"dev": true,
+			"requires": {
+				"xmlchars": "^2.1.1"
+			}
+		},
 		"scoped-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
@@ -11529,11 +14705,58 @@
 				"semver": "^5.0.3"
 			}
 		},
+		"send": {
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"destroy": "~1.0.4",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "~1.7.2",
+				"mime": "1.6.0",
+				"ms": "2.1.1",
+				"on-finished": "~2.3.0",
+				"range-parser": "~1.2.1",
+				"statuses": "~1.5.0"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
 		"serialize-javascript": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
 			"integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
 			"dev": true
+		},
+		"serialize-to-js": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.0.2.tgz",
+			"integrity": "sha512-o5FqeMyxGx1wkp8p14q9QqGXh1JjXtIDYTr15N/B4ThM5ULqlpXdtOO84m950jFGvBkeRD1utW+WyNKvao2ybQ==",
+			"dev": true
+		},
+		"serve-static": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+			"dev": true,
+			"requires": {
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.3",
+				"send": "0.17.1"
+			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -11561,6 +14784,34 @@
 					}
 				}
 			}
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
+		},
+		"setprototypeof": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+			"dev": true
+		},
+		"sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"shallow-copy": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+			"integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=",
+			"dev": true
 		},
 		"shebang-command": {
 			"version": "1.2.0",
@@ -11905,6 +15156,43 @@
 			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
 			"dev": true
 		},
+		"static-eval": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.3.tgz",
+			"integrity": "sha512-zsxDGucfAh8T339sSKgpFbvg15Fms2IVaJGC+jqp0bVsxhcpM+iMeAI8weNo8dmf4OblgifTBUoyk1vGVtYw2w==",
+			"dev": true,
+			"requires": {
+				"escodegen": "^1.11.1"
+			},
+			"dependencies": {
+				"escodegen": {
+					"version": "1.12.0",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+					"integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+					"dev": true,
+					"requires": {
+						"esprima": "^3.1.3",
+						"estraverse": "^4.2.0",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.6.1"
+					}
+				},
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -11922,6 +15210,83 @@
 						"is-descriptor": "^0.1.0"
 					}
 				}
+			}
+		},
+		"static-module": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
+			"integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
+			"dev": true,
+			"requires": {
+				"concat-stream": "~1.6.0",
+				"convert-source-map": "^1.5.1",
+				"duplexer2": "~0.1.4",
+				"escodegen": "~1.9.0",
+				"falafel": "^2.1.0",
+				"has": "^1.0.1",
+				"magic-string": "^0.22.4",
+				"merge-source-map": "1.0.4",
+				"object-inspect": "~1.4.0",
+				"quote-stream": "~1.0.2",
+				"readable-stream": "~2.3.3",
+				"shallow-copy": "~0.0.1",
+				"static-eval": "^2.0.0",
+				"through2": "~2.0.3"
+			},
+			"dependencies": {
+				"magic-string": {
+					"version": "0.22.5",
+					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+					"integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+					"dev": true,
+					"requires": {
+						"vlq": "^0.2.2"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+					"integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+					"dev": true,
+					"requires": {
+						"source-map": "^0.5.6"
+					}
+				}
+			}
+		},
+		"statuses": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+			"dev": true
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
+		},
+		"stream-browserify": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+			"integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+			"dev": true,
+			"requires": {
+				"inherits": "~2.0.1",
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"stream-http": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+			"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+			"dev": true,
+			"requires": {
+				"builtin-status-codes": "^3.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.3.6",
+				"to-arraybuffer": "^1.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"strict-uri-encode": {
@@ -12098,6 +15463,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
 			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+			"dev": true
+		},
+		"symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
 		},
 		"table": {
@@ -12315,11 +15686,30 @@
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
+		"through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			}
+		},
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
 			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
 			"dev": true
+		},
+		"timers-browserify": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+			"integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+			"dev": true,
+			"requires": {
+				"setimmediate": "^1.0.4"
+			}
 		},
 		"timsort": {
 			"version": "0.3.0",
@@ -12337,6 +15727,12 @@
 				"globrex": "^0.1.1"
 			}
 		},
+		"tiny-inflate": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+			"integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+			"dev": true
+		},
 		"tlds": {
 			"version": "1.203.1",
 			"resolved": "https://registry.npmjs.org/tlds/-/tlds-1.203.1.tgz",
@@ -12351,6 +15747,12 @@
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
+		},
+		"to-arraybuffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+			"dev": true
 		},
 		"to-buffer": {
 			"version": "1.1.1",
@@ -12408,6 +15810,12 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
+		"toidentifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+			"dev": true
+		},
 		"touch": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -12433,6 +15841,15 @@
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true
 				}
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
 			}
 		},
 		"trim-newlines": {
@@ -12465,6 +15882,12 @@
 			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
 			"dev": true
 		},
+		"tty-browserify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+			"dev": true
+		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -12495,36 +15918,62 @@
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
+		"type-fest": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+			"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
 		"typescript": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
 			"integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
 			"dev": true
 		},
-		"uglify-js": {
-			"version": "3.6.9",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
-			"integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
+		"uncss": {
+			"version": "0.17.2",
+			"resolved": "https://registry.npmjs.org/uncss/-/uncss-0.17.2.tgz",
+			"integrity": "sha512-hu2HquwDItuGDem4YsJROdAD8SknmWtM24zwhQax6J1se8tPjV1cnwPKhtjodzBaUhaL8Zb3hlGdZ2WAUpbAOg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"commander": "~2.20.3",
-				"source-map": "~0.6.1"
+				"commander": "^2.20.0",
+				"glob": "^7.1.4",
+				"is-absolute-url": "^3.0.1",
+				"is-html": "^1.1.0",
+				"jsdom": "^14.1.0",
+				"lodash": "^4.17.15",
+				"postcss": "^7.0.17",
+				"postcss-selector-parser": "6.0.2",
+				"request": "^2.88.0"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true,
-					"optional": true
+				"cssesc": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+					"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+					"dev": true
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+				"is-absolute-url": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+					"integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+					"dev": true
+				},
+				"postcss-selector-parser": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+					"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
 					"dev": true,
-					"optional": true
+					"requires": {
+						"cssesc": "^3.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
 				}
 			}
 		},
@@ -12564,6 +16013,16 @@
 			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
 			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
 			"dev": true
+		},
+		"unicode-trie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-0.3.1.tgz",
+			"integrity": "sha1-1nHd3YkQGgi6w3tqUWEBBgIFIIU=",
+			"dev": true,
+			"requires": {
+				"pako": "^0.2.5",
+				"tiny-inflate": "^1.0.0"
+			}
 		},
 		"union-value": {
 			"version": "1.0.1",
@@ -12689,6 +16148,24 @@
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
+		"url": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"dev": true,
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+					"dev": true
+				}
+			}
+		},
 		"url-parse-lax": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -12713,6 +16190,23 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
+		"util": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+			"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true
+				}
+			}
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -12733,6 +16227,12 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"dev": true
+		},
+		"v8-compile-cache": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -12775,6 +16275,73 @@
 			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
 			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
 			"dev": true
+		},
+		"vm-browserify": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+			"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+			"dev": true
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"dev": true,
+			"requires": {
+				"browser-process-hrtime": "^0.1.2"
+			}
+		},
+		"w3c-xmlserializer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+			"integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+			"dev": true,
+			"requires": {
+				"domexception": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"xml-name-validator": "^3.0.0"
+			}
+		},
+		"wcwidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+			"dev": true,
+			"requires": {
+				"defaults": "^1.0.3"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"dev": true
+		},
+		"whatwg-encoding": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+			"dev": true,
+			"requires": {
+				"iconv-lite": "0.4.24"
+			}
+		},
+		"whatwg-mimetype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+			"dev": true
+		},
+		"whatwg-url": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+			"dev": true,
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
 		},
 		"whet.extend": {
 			"version": "0.9.9",
@@ -12876,10 +16443,31 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
+		"ws": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+			"dev": true,
+			"requires": {
+				"async-limiter": "~1.0.0"
+			}
+		},
 		"xdg-basedir": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
 			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+			"dev": true
+		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
+		},
+		"xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
 		},
 		"xtend": {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,9 @@
 		"test:watch": "nodemon --watch test -e .ts --exec npm test"
 	},
 	"devDependencies": {
-		"@babel/cli": "7.4.3",
+		"@babel/cli": "^7.8.4",
 		"@babel/core": "7.4.3",
+		"@babel/plugin-transform-runtime": "^7.9.0",
 		"@babel/preset-env": "7.4.3",
 		"@babel/preset-typescript": "7.3.3",
 		"@types/chai": "4.1.7",
@@ -81,6 +82,7 @@
 		"np": "3.1.0",
 		"npm-run-all": "4.1.5",
 		"nyc": "14.1.1",
+		"parcel-bundler": "1.12.4",
 		"prettier": "1.16.4",
 		"rimraf": "2.6.3",
 		"sinon": "7.3.1",
@@ -91,7 +93,8 @@
 	"dependencies": {
 		"globby": "^9.2.0",
 		"meow": "5.0.0",
-		"parse-dotenv": "2.1.0"
+		"parse-dotenv": "2.1.0",
+		"pkg-conf": "^3.1.0"
 	},
 	"nyc": {
 		"extension": [

--- a/test/lib.spec.ts
+++ b/test/lib.spec.ts
@@ -109,55 +109,26 @@ describe("sync-dotenv lib", () => {
 	});
 
 	describe("getUniqueVarsFromEnv()", () => {
-		it("remove object property values", () => {
+		it("remove object property values", async () => {
 			const envObj = { name: "angry" };
 			const exampleEnvObj = { foo: "bar", name: "bird" };
-			const uniqueVarsArr = lib.getUniqueVarsFromEnvs(envObj, exampleEnvObj);
+			const uniqueVarsArr = await lib.getUniqueVarsFromEnvs(
+				envObj,
+				exampleEnvObj
+			);
 
 			expect(uniqueVarsArr.length).equals(1);
 			expect(uniqueVarsArr[0]).to.have.deep.property("name", "bird");
 		});
 	});
 
-	describe("removeStaleVarsFromEnv()", () => {
-		it("remove object property values", () => {
-			const envObj = {
-				APP_NAME: "awesomeapp",
-				APP_URL: "https://awesomeapp.io"
-			};
-			const exampleEnvObj = {
-				foo: "bar",
-				APP_URL: "https://localhost:3000"
-			};
-			const varsObj = lib.getUniqueVarsFromEnvs(envObj, exampleEnvObj);
-			const latestVars = lib.removeStaleVarsFromEnv(envObj, varsObj);
-
-			expect(latestVars).to.have.deep.property("APP_NAME", "");
-			expect(latestVars).to.have.deep.property(
-				"APP_URL",
-				exampleEnvObj.APP_URL
-			);
-			expect(latestVars).to.not.have.deep.property("foo");
-		});
-	});
-
-	describe("getParsedEnvs()", () => {
-		it("gets result of two envs parsed", () => {
-			const envObj = {
-				PORT: "5439"
-			};
-			const parsedEnvsResult = lib.getParsedEnvs(envObj, {});
-			expect(parsedEnvsResult).to.have.deep.property("PORT", "");
-		});
-	});
-
 	describe("syncWithExampleEnv()", () => {
-		it("sync .env with example env", () => {
+		it("sync .env with example env", async () => {
 			createFile(ENV_PATH, ENV_DATA);
 
 			const writeToExampleEnvSpy = sandbox.spy(lib, "writeToSampleEnv");
 
-			lib.syncWithSampleEnv(ENV_PATH, SAMPLE_ENV_PATH);
+			await lib.syncWithSampleEnv(ENV_PATH, SAMPLE_ENV_PATH);
 
 			expect(writeToExampleEnvSpy).callCount(1);
 		});

--- a/test/lib.spec.ts
+++ b/test/lib.spec.ts
@@ -180,9 +180,9 @@ describe("sync-dotenv lib", () => {
 			});
 		});
 
-		it("syncs multiple sample env files", () => {
+		it("syncs multiple sample env files", async () => {
 			const spy = sandbox.spy(lib, "syncWithSampleEnv");
-			lib.syncEnv(undefined, undefined, ".env.*");
+			await lib.syncEnv(undefined, undefined, ".env.*");
 			expect(spy).callCount(2);
 		});
 


### PR DESCRIPTION
## What does this PR do?
Keeps variables value in sample env file and allows users to optionally set which variables to preserve during sync.

Sometimes you need to preserve certain variables in your sample env file, you can optionally allow this by adding a `sync-dotenv` config in `package.json` like so

```js
// package.json
"scripts": {
  ...
},
"sync-dotenv": {
  "preserve": ["CHANNEL"]
}
```

## Previous behaviour
`.env` is treated as the source of truth. This library removes variables in sample env file that are not in `.env` to keep the files in sync

For more context, please take a look at these issues #25 , #26 

resolves #25, resolves #26 