### PR TITLE
Allow to pass option to avoid comments and emptyLines in sample env

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,22 @@ Sometimes you need to preserve certain variables in your example env file, you c
 }
 ```
 
+### Avoid comments or empty lines in sample env
+
+You might not want to copy empty lines or comments to your sample env, in this case you can still use `sync-dotenv` config in `package.json` with the following:
+
+```js
+// package.json
+"scripts": {
+  ...
+},
+"sync-dotenv": {
+  "emptyLines": true,
+  "comments": false
+}
+```
+Note that you can still combine those options with `preserve`.
+
 ## Related
 
 - [parse-dotenv](https://github.com/codeshifu/parse-dotenv) - zero dependency `.env` to javascript object parser

--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -13,7 +13,9 @@ interface EnvObject {
 }
 
 interface Config {
-	preserve: [string];
+	preserve?: [string];
+	emptyLines?: boolean;
+	comments?: boolean;
 }
 
 export const fileExists = (path: string) => fs.existsSync(path);
@@ -27,9 +29,9 @@ export const envToString = (parsed: EnvObject) =>
 		.replace(/(__\w+_\d+__=)/g, "");
 
 export const writeToSampleEnv = (path: string, parsedEnv: object) => {
-	try{
+	try {
 		fs.writeFileSync(path, envToString(parsedEnv));
-	}catch (e) {
+	} catch (e) {
 		throw new Error(`Sync failed. ${e.message}`);
 	}
 };
@@ -60,9 +62,9 @@ export const emptyObjProps = (obj: EnvObject) => {
 
 export const getUniqueVarsFromEnvs = async (
 	env: EnvObject,
-	envExample: EnvObject
+	envExample: EnvObject,
+	config: Config = {}
 ) => {
-	let config: Config = (await pkgConf("sync-dotenv")) as any;
 	let ignoreKeys = config.preserve || [];
 
 	const uniqueKeys = new Set(getObjKeys(env));
@@ -76,7 +78,7 @@ export const getUniqueVarsFromEnvs = async (
 	let presevedVars = getObjKeys(envExample)
 		.map(key => ({ [key]: envExample[key] }))
 		.filter(env => {
-			return ignoreKeys.includes(getObjKeys(env)[0]);
+			return ignoreKeys.length && ignoreKeys.includes(getObjKeys(env)[0]);
 		});
 
 	return [...uniqueFromSource, ...presevedVars];
@@ -84,14 +86,17 @@ export const getUniqueVarsFromEnvs = async (
 
 export const syncWithSampleEnv = async (
 	envPath: string,
-	envExamplePath: string
+	envExamplePath: string,
+	initialConfig?: Config
 ) => {
+	// We do this so we can pass it via test as well
+	let config: Config = initialConfig || (await pkgConf("sync-dotenv")) as any;
 	let sourceEnv = emptyObjProps(
-		parseEnv(envPath, { emptyLines: true, comments: true })
+		parseEnv(envPath, { emptyLines: !!config.emptyLines, comments: !!config.comments })
 	);
 	let targetEnv = parseEnv(envExamplePath);
 
-	const uniqueVars = await getUniqueVarsFromEnvs(sourceEnv, targetEnv);
+	const uniqueVars = await getUniqueVarsFromEnvs(sourceEnv, targetEnv, config);
 	let envCopy: EnvObject = {};
 	uniqueVars.forEach(env => {
 		let [key] = getObjKeys(env);
@@ -115,8 +120,8 @@ export const syncEnv = async (
 	const SAMPLE_ENV_PATHS: string[] = !samples
 		? [resolve(process.cwd(), sampleEnv || DEFAULT_SAMPLE_ENV)]
 		: globby
-				.sync(samples)
-				.map((sample: string) => resolve(process.cwd(), sample));
+			.sync(samples)
+			.map((sample: string) => resolve(process.cwd(), sample));
 
 	let envPath = source
 		? fileExists(source)

--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -91,6 +91,11 @@ export const syncWithSampleEnv = async (
 ) => {
 	// We do this so we can pass it via test as well
 	let config: Config = initialConfig || (await pkgConf("sync-dotenv")) as any;
+
+	// Set defaults
+	config.comments = typeof config.comments === 'undefined' ? true : config.comments;
+	config.emptyLines = typeof config.emptyLines === 'undefined' ? true : config.comments;
+
 	let sourceEnv = emptyObjProps(
 		parseEnv(envPath, { emptyLines: !!config.emptyLines, comments: !!config.comments })
 	);

--- a/test/lib.spec.ts
+++ b/test/lib.spec.ts
@@ -17,7 +17,7 @@ const ENV_PATH = resolve(process.cwd(), ENV_FILENAME);
 const SAMPLE_ENV_PATH = resolve(process.cwd(), ".env.example");
 const SAMPLE_ENV_PATH_2 = resolve(process.cwd(), ".env.sample");
 
-const createFile = (path: string, data = "", cb: Callback = () => {}) => {
+const createFile = (path: string, data = "", cb: Callback = () => { }) => {
 	fs.writeFileSync(path, data, { encoding: "utf-8" });
 };
 
@@ -124,9 +124,10 @@ describe("sync-dotenv lib", () => {
 
 			const writeToExampleEnvSpy = sandbox.spy(lib, "writeToSampleEnv");
 
-			await lib.syncWithSampleEnv(ENV_PATH, SAMPLE_ENV_PATH);
+			await lib.syncWithSampleEnv(ENV_PATH, SAMPLE_ENV_PATH, { comments: false });
 
 			expect(writeToExampleEnvSpy).callCount(1);
+			expect(writeToExampleEnvSpy.getCalls()[0].lastArg).to.not.haveOwnProperty('__COMMENT_1__');
 		});
 	});
 


### PR DESCRIPTION
If we have a pre-commit hook set-up and for some reason we comment a secret, this might end up commited. To avoid this, we can give the option to avoid comments or even empty lines.

Given the problem, this PR gives the lib the ability to accept those options and avoid any further problem with secrets commit on sample envs.

NOTE: This problem happened to me and to my colleagues so I think it is reasonable to have this feature.