### PR TITLE
Update globby to 11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"typescript": "^3.9.7"
 	},
 	"dependencies": {
-		"globby": "^9.2.0",
+		"globby": "^11.1.0",
 		"meow": "5.0.0",
 		"parse-dotenv": "2.1.0",
 		"pkg-conf": "^3.1.0"


### PR DESCRIPTION
Updates globby from 9.2 to 11.1 due to deprecated dependencies.

```bash
$ npm test

> sync-dotenv@2.7.0 test
> nyc --reporter=html --reporter=text mocha



  sync-dotenv lib
    fileExists()
      ✓ fails to find .env file
      ✓ finds .env file
    getObjKeys
      ✓ get object keys
    writeToSampleEnv()
      ✓ writes to a .env.example successfully (502ms)
      ✓ failed to write a .env.example successfully
    emptyObjProps()
      ✓ remove object property values
    getUniqueVarsFromEnv()
      ✓ remove object property values
    syncWithExampleEnv()
      ✓ sync .env with example env
    syncEnv
      ✓ fails to sync with source (.env) file
      ✓ fails when .env is not found in project root
      ✓ throw error for missing sample env
      ✓ throw error for missing sample env
      ✓ uses existing sample env if available
      ✓ should error out if provided regex matched no files
      ✓ syncs multiple sample env files
      ✓ strips all empty line entries
      ✓ error for invalid env source
      ✓ syncs with provided source


  18 passing (544ms)

----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |      100 |    95.83 |      100 |      100 |                   |
 lib.ts   |      100 |    95.83 |      100 |      100 |             81,97 |
----------|----------|----------|----------|----------|-------------------|
```

Closes #48 